### PR TITLE
remove unnecessary print when RxChannel has been disposed

### DIFF
--- a/RxBiBinding/Classes/RxChannel.swift
+++ b/RxBiBinding/Classes/RxChannel.swift
@@ -161,7 +161,5 @@ extension RxChannel {
 
 //MARK: - Disposable RxChannel
 extension RxChannel: Disposable {
-    func dispose() {
-        print("RxChannel -> dispose")
-    }
+    func dispose() {}
 }


### PR DESCRIPTION
see https://github.com/RxSwiftCommunity/RxBiBinding/issues/37